### PR TITLE
fix: page body column size

### DIFF
--- a/common.php
+++ b/common.php
@@ -29,7 +29,7 @@ if (version_compare(phpversion(), '7.4', '<')) die('PHP version 7.4 or higher is
 
 define('MYAAC', true);
 define('MYAAC_VERSION', '0.8.16');
-define('DATABASE_VERSION', 34);
+define('DATABASE_VERSION', 35);
 define('TABLE_PREFIX', 'myaac_');
 define('START_TIME', microtime(true));
 define('MYAAC_OS', stripos(PHP_OS, 'WIN') === 0 ? 'WINDOWS' : (strtoupper(PHP_OS) === 'DARWIN' ? 'MAC' : 'LINUX'));

--- a/install/includes/schema.sql
+++ b/install/includes/schema.sql
@@ -284,7 +284,7 @@ CREATE TABLE `myaac_pages`
 	`id` INT NOT NULL AUTO_INCREMENT,
 	`name` VARCHAR(30) NOT NULL,
 	`title` VARCHAR(30) NOT NULL,
-	`body` TEXT NOT NULL,
+	`body` LONGTEXT NOT NULL,
 	`date` INT(11) NOT NULL DEFAULT 0,
 	`player_id` INT(11) NOT NULL DEFAULT 0,
 	`php` TINYINT(1) NOT NULL DEFAULT 0 COMMENT '0 - plain html, 1 - php',

--- a/system/migrations/35.php
+++ b/system/migrations/35.php
@@ -1,0 +1,3 @@
+<?php
+// Alter column type so we can have bigger pages.
+$db->exec('ALTER TABLE myaac_pages CHANGE body body LONGTEXT CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL;');


### PR DESCRIPTION
This PR will give the possibility of creating bigger pages, with more content.

Attention: if you have already installed MyAAC, you will need to change the table structure manually.
The following SQL command will do the trick:

`ALTER TABLE `myaac_pages` CHANGE `body` `body` LONGTEXT CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL;`