### PR TITLE
fix: log in automatically after create account by client

### DIFF
--- a/clientcreateaccount.php
+++ b/clientcreateaccount.php
@@ -262,23 +262,21 @@ function createAccount(array $data)
       }
     }
 
-        
-        // Start an output buffer
-        ob_start();
+    // Start an output buffer
+    ob_start();
 
-        // Character creation starts in dawnport
-        if (count(config('character_samples')) == 1 && !empty($data['characterName'])) {
-            require_once LIBS . 'CreateCharacter.php';
-            $createCharacter = new CreateCharacter();
+    // character creation only if start in dawnport
+    if (count(config('character_samples')) == 1 && !empty($data['characterName'])) {
+      require_once LIBS . 'CreateCharacter.php';
+      $createCharacter = new CreateCharacter();
+      $errors = [];
+      if (!$createCharacter->doCreate($data['characterName'], $data['characterSex'], 0, 0, $new_account, $errors)) {
+        throw new Exception('There was an error creating your character. Please create your character later in account management page.');
+      }
+    }
 
-            $errors = [];
-            if (!$createCharacter->doCreate($data['characterName'], $data['characterSex'], 0, 0, $new_account, $errors)) {
-                throw new Exception('There was an error creating your character. Please create your character later in account management page.');
-            }
-        }
-
-        // Clears and closes the output buffer
-        ob_end_clean();
+    // Clear and closes the output buffer
+    ob_end_clean();
 
     return $account_name;
   } catch (Exception $e) {

--- a/clientcreateaccount.php
+++ b/clientcreateaccount.php
@@ -262,10 +262,11 @@ function createAccount(array $data)
       }
     }
 
-        // Inicia um buffer de saída
+        
+        // Start an output buffer
         ob_start();
 
-        // Criação de personagem se iniciar em dawnport
+        // Character creation starts in dawnport
         if (count(config('character_samples')) == 1 && !empty($data['characterName'])) {
             require_once LIBS . 'CreateCharacter.php';
             $createCharacter = new CreateCharacter();
@@ -276,7 +277,7 @@ function createAccount(array $data)
             }
         }
 
-        // Limpa e fecha o buffer de saída
+        // Clears and closes the output buffer
         ob_end_clean();
 
     return $account_name;

--- a/clientcreateaccount.php
+++ b/clientcreateaccount.php
@@ -262,15 +262,22 @@ function createAccount(array $data)
       }
     }
 
-    // character creation only if start in dawnport
-    if (count(config('character_samples')) == 1 && !empty($data['characterName'])) {
-      require_once LIBS . 'CreateCharacter.php';
-      $createCharacter = new CreateCharacter();
-      $errors = [];
-      if (!$createCharacter->doCreate($data['characterName'], $data['characterSex'], 0, 0, $new_account, $errors)) {
-        throw new Exception('There was an error creating your character. Please create your character later in account management page.');
-      }
-    }
+        // Inicia um buffer de saída
+        ob_start();
+
+        // Criação de personagem se iniciar em dawnport
+        if (count(config('character_samples')) == 1 && !empty($data['characterName'])) {
+            require_once LIBS . 'CreateCharacter.php';
+            $createCharacter = new CreateCharacter();
+
+            $errors = [];
+            if (!$createCharacter->doCreate($data['characterName'], $data['characterSex'], 0, 0, $new_account, $errors)) {
+                throw new Exception('There was an error creating your character. Please create your character later in account management page.');
+            }
+        }
+
+        // Limpa e fecha o buffer de saída
+        ob_end_clean();
 
     return $account_name;
   } catch (Exception $e) {


### PR DESCRIPTION
The lib function, being large, generates 1 or 2 seconds of delay and this does not allow return to be executed and logging into the account with these buffers will be allowed after creating the account to log in automatically
