### PR TITLE
Feat: Add ability to list all accounts and players in admin editor.

### DIFF
--- a/admin/pages/accounts.php
+++ b/admin/pages/accounts.php
@@ -55,7 +55,7 @@ if ($config['account_country']) {
 }
 ?>
 
-<link rel="stylesheet" type="text/css" href="<?= BASE_URL; ?>tools/css/jquery.datetimepicker.css"/ >
+<link rel="stylesheet" type="text/css" href="<?= BASE_URL; ?>tools/css/jquery.datetimepicker.css"/>
 <script src="<?= BASE_URL; ?>tools/js/jquery.datetimepicker.js"></script>
 
 <?php
@@ -68,18 +68,18 @@ else if ($searchName = $_REQUEST['search_name'] ?? null) {
     } else {
         if (Validator::number($searchName)) {
             $id = $searchName;
-            $query = $db->query("SELECT `id` FROM `accounts` WHERE `name` = {$id}");
+            $query = $db->query("SELECT id FROM accounts WHERE name = {$id}");
             if ($query->rowCount() == 1) {
                 $query = $query->fetch();
                 $id = $query['id'];
             }
         } else {
-            $query = $db->query("SELECT `id` FROM `accounts` WHERE `name` = {$db->quote($searchName)}");
+            $query = $db->query("SELECT id FROM accounts WHERE name = {$db->quote($searchName)}");
             if ($query->rowCount() == 1) {
                 $query = $query->fetch();
                 $id = $query['id'];
             } else {
-                $query = $db->query("SELECT `id`, `name` FROM `accounts` WHERE `name` LIKE {$db->quote("%{$searchName}%")}");
+                $query = $db->query("SELECT id, name FROM accounts WHERE name LIKE {$db->quote("%{$searchName}%")}");
                 if ($query->rowCount() > 0 && $query->rowCount() <= 10) {
                     echo 'Do you mean?<ul>';
                     foreach ($query as $row)
@@ -91,6 +91,8 @@ else if ($searchName = $_REQUEST['search_name'] ?? null) {
         }
     }
 }
+
+
 $groups = new OTS_Groups_List();
 if ($id > 0) {
     $account = new OTS_Account();
@@ -457,7 +459,7 @@ else if ($id > 0 && isset($account) && $account->isLoaded()) {
     <?php
     if (isset($account) && $account->isLoaded()) {
         $account_players = array();
-        $query = $db->query('SELECT `name`,`level`,`vocation`  FROM `players` WHERE `account_id` = ' . $account->getId() . ' ORDER BY `name`')->fetchAll();
+        $query = $db->query('SELECT name,level,vocation  FROM players WHERE account_id = ' . $account->getId() . ' ORDER BY name')->fetchAll();
         if (isset($query)) {
             ?>
             <div class="box">
@@ -495,7 +497,25 @@ else if ($id > 0 && isset($account) && $account->isLoaded()) {
     };
     ?>
 </div>
-
+<?php 
+// List all accounts
+$allAccounts = $db->query("SELECT id, name, email FROM accounts ORDER BY id ASC")->fetchAll();
+if ($allAccounts) {
+    echo '<h3>All Accounts:</h3>';
+    echo '<table class="table table-striped">';
+    echo '<thead><tr><th>ID</th><th>Account Name</th><th>Email</th></tr></thead>';
+    echo '<tbody>';
+    foreach ($allAccounts as $accountRow) {
+        echo '<tr>';
+        echo '<td>' . $accountRow['id'] . '</td>';
+        echo '<td><a href="' . $base . '&id=' . $accountRow['id'] . '">' . $accountRow['name'] . '</a></td>';
+        echo '<td>' . $accountRow['email'] . '</td>';
+        echo '</tr>';
+    }
+    echo '</tbody>';
+    echo '</table>';
+}
+?>
 <script type="text/javascript">
     $('#lastlogout').datetimepicker({format: 'unixtime'});
     $('#created').datetimepicker({format: 'unixtime'});

--- a/admin/pages/players.php
+++ b/admin/pages/players.php
@@ -895,3 +895,22 @@ else if ($id > 0 && isset($player) && $player->isLoaded())
             console.log(new_outfit);
         }
 	</script>
+<?php 
+// List all players
+$allAccounts = $db->query("SELECT id, name, account_id FROM players ORDER BY id ASC")->fetchAll();
+if ($allAccounts) {
+    echo '<h3>All Accounts:</h3>';
+    echo '<table class="table table-striped">';
+    echo '<thead><tr><th>ID</th><th>Player Name</th><th>Account Name</th></tr></thead>';
+    echo '<tbody>';
+    foreach ($allAccounts as $accountRow) {
+        echo '<tr>';
+        echo '<td>' . $accountRow['id'] . '</td>';
+        echo '<td><a href="' . $base . '&id=' . $accountRow['id'] . '">' . $accountRow['name'] .'</a></td>';
+        echo '<td>' . $accountRow['account_id'] . '</td>';
+        echo '</tr>';
+    }
+    echo '</tbody>';
+    echo '</table>';
+}
+?>


### PR DESCRIPTION
Temporary Feature.

# Description

This pull request introduces a new feature that allows administrators to list all accounts and players directly within the admin editor pages:

- **Account Editor:** All accounts are now displayed in a table format, with columns for ID, Name, and Email, and an option to edit each account. This provides a comprehensive view of all accounts, making it easier to manage and edit them from one location.

- **Player Editor:** Players linked to an account are now listed in a table format, along with an edit option for each player. This functionality allows for a more organized and efficient management of players within the admin panel.

These enhancements significantly improve the admin interface, making it easier to access and manage both accounts and players. 

### Fixes #114

## Type of change

  - [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested

**Test Configuration**:

  - MyAAC Version: (latest: 0.8.16)
  - Browser:
    - [x] Chrome
    - [x] Opera
  
  - Operating System:
    - [x] Windows
    - [x] Ubuntu


## Checklist

  - [x] I've created separated branch from main updated
  - [x] My code follows the style guidelines of this project
  - [x] I followed project rules, best practices, and code indentation
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports 
  - [x] I have commented on my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
