### PR TITLE
feat: database encryption and port

### DIFF
--- a/config.php
+++ b/config.php
@@ -78,6 +78,7 @@ $config = array(
 	'database_log' => false, // should database queries be logged and and saved into system/logs/database.log?
 	'database_socket' => '', // set if you want to connect to database through socket (example: /var/run/mysqld/mysqld.sock)
 	'database_persistent' => false, // use database permanent connection (like server), may speed up your site
+	'database_encryption' => 'sha1',
 
 	// multiworld system (only TFS 0.3)
 	'multiworld' => false, // use multiworld system?

--- a/system/database.php
+++ b/system/database.php
@@ -103,6 +103,7 @@ if (!isset($config['database_socket'])) {
 try {
   $ots->connect([
     'host' => $config['database_host'],
+    'port' => $config['database_port'],
     'user' => $config['database_user'],
     'password' => $config['database_password'],
     'database' => $config['database_name'],


### PR DESCRIPTION
# Description

Add `'database_encryption' => 'sha1',`  in case of filling in the information in the database details.
Add `'port' => $config['database_port'],` in case of mysql port change.

## Type of change

  - [X] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

**Test Configuration**:

  - MyAAC Version: (latest: 0.8.16)
  - Browser:
    - [ ] Chrome
    - [ ] Firefox
    - [ ] Opera
    - [ ] Safari
    - [X] Edge
    - [ ] Other
  - Operating System:
    - [X] Windows
    - [ ] Ubuntu
    - [ ] MacOS
    - [ ] Other

## Checklist

  - [X] I've created separated branch from main updated
  - [X] My code follows the style guidelines of this project
  - [X] I followed project rules, best practices, and code indentation
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports 
  - [ ] I have commented on my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
