### PR TITLE
feat: add option to hide staff accounts from online list

### DIFF
--- a/config.php
+++ b/config.php
@@ -259,6 +259,9 @@ $config = array(
 	'highscores_ids_hidden' => array(0), // this ids of players will be hidden on the highscores (should be ids of samples)
 	'highscores_length' => 100, // how many records per page on highscores
 
+	// Online list configuration
+	'hide_staff_on_online_list' => true, // true to hide GOD/GMs/CMs (account type > 3) from online list, false to show all
+
 	// characters page
 	'characters' => array( // what things to display on character view page (true/false in each option)
 		'level' => true,

--- a/system/pages/online.php
+++ b/system/pages/online.php
@@ -53,10 +53,36 @@ if($config['online_vocations']) {
 	}
 }
 
-if($db->hasTable('players_online')) // tfs 1.0
-	$playersOnline = $db->query('SELECT `accounts`.`country`, `players`.`name`, `players`.`level`, `players`.`vocation`' . $outfit . ', `' . $skull_time . '` as `skulltime`, `' . $skull_type . '` as `skull` FROM `accounts`, `players`, `players_online` WHERE `players`.`id` = `players_online`.`player_id` AND `accounts`.`id` = `players`.`account_id`  ORDER BY ' . $order);
-else
-	$playersOnline = $db->query('SELECT `accounts`.`country`, `players`.`name`, `players`.`level`, `players`.`vocation`' . $outfit . ', ' . $promotion . ' `' . $skull_time . '` as `skulltime`, `' . $skull_type . '` as `skull` FROM `accounts`, `players` WHERE `players`.`online` > 0 AND `accounts`.`id` = `players`.`account_id`  ORDER BY ' . $order);
+$hideStaffCondition = '';
+if ($config['hide_staff_on_online_list']) {
+    if ($db->hasColumn('accounts', 'type')) {
+        $hideStaffCondition = ' AND `accounts`.`type` <= 3';
+    } elseif ($db->hasColumn('accounts', 'group_id')) {
+        $hideStaffCondition = ' AND `accounts`.`group_id` <= 3';
+    }
+}
+
+if($db->hasTable('players_online')) { // tfs 1.0
+    $playersOnline = $db->query('
+        SELECT `accounts`.`country`, `players`.`name`, `players`.`level`, `players`.`vocation`' . $outfit . ', 
+        `' . $skull_time . '` as `skulltime`, `' . $skull_type . '` as `skull` 
+        FROM `accounts`, `players`, `players_online` 
+        WHERE `players`.`id` = `players_online`.`player_id` 
+        AND `accounts`.`id` = `players`.`account_id`
+        ' . $hideStaffCondition . '
+        ORDER BY ' . $order
+    );
+} else { // tfs 0.x
+    $playersOnline = $db->query('
+        SELECT `accounts`.`country`, `players`.`name`, `players`.`level`, `players`.`vocation`' . $outfit . ', 
+        ' . $promotion . ' `' . $skull_time . '` as `skulltime`, `' . $skull_type . '` as `skull` 
+        FROM `accounts`, `players` 
+        WHERE `players`.`online` > 0 
+        AND `accounts`.`id` = `players`.`account_id`
+        ' . $hideStaffCondition . '
+        ORDER BY ' . $order
+    );
+}
 
 $players_data = array();
 $explodeFlags = array();


### PR DESCRIPTION
# Description

Added new configuration option `hide_staff_on_online_list` to control visibility of staff members (account type > 3) in the online list. This provides server owners with flexibility to show/hide GMs/CMs from the public online list.

## Behaviour
### **Actual**

Currently, the online list shows all players including staff members (GMs/CMs) with no configuration option to hide them.

### **Expected**

When `hide_staff_on_online_list` is set to true in config.php, staff members (account type > 3) should be hidden from the online list while normal players remain visible.

### Fixes #132

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [X] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

**Test Configuration**:

  - MyAAC Version: (latest: 0.8.16)
  - Browser:
    - [X] Chrome
    - [] Firefox
    - [ ] Opera
    - [ ] Safari
    - [ ] Edge
    - [ ] Other
  - Operating System:
    - [X] Windows
    - [ ] Ubuntu
    - [ ] MacOS
    - [ ] Other

## Checklist

  - [X] I've created separated branch from main updated
  - [X] My code follows the style guidelines of this project
  - [X] I followed project rules, best practices, and code indentation
  - [X] I have performed a self-review of my own code
  - [X] I checked the PR checks reports 
  - [X] I have commented on my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
